### PR TITLE
Remove main() functions from lost item screens

### DIFF
--- a/campus_lost_found_app/lib/features/lost_items/screens/lost_item_details_screen.dart
+++ b/campus_lost_found_app/lib/features/lost_items/screens/lost_item_details_screen.dart
@@ -1,11 +1,5 @@
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(MaterialApp(
-    debugShowCheckedModeBanner: false,
-    home: LostItemDetailsScreen(),
-  ));
-}
 
 class LostItemDetailsScreen extends StatefulWidget {
   @override

--- a/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
+++ b/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
@@ -1,11 +1,5 @@
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(MaterialApp(
-    debugShowCheckedModeBanner: false,
-    home: ReportLostItemScreen(),
-  ));
-}
 
 class ReportLostItemScreen extends StatefulWidget {
   @override


### PR DESCRIPTION
Removed the main() function from lost_item_details_screen.dart and report_lost_item_screen.dart.