### PR TITLE
Refactor navigation and headers across Lost & Found screens

### DIFF
--- a/campus_lost_found_app/lib/features/found_items/screens/found_items_list_screen.dart
+++ b/campus_lost_found_app/lib/features/found_items/screens/found_items_list_screen.dart
@@ -7,44 +7,28 @@ class FoundItemsScreen extends StatefulWidget {
   const FoundItemsScreen({super.key});
 
   @override
-  _FoundItemsScreenState createState() => _FoundItemsScreenState();
+  State<FoundItemsScreen> createState() => _FoundItemsScreenState();
 }
 
 class _FoundItemsScreenState extends State<FoundItemsScreen> {
   int _selectedIndex = 2;
-  late final List<Widget> _screens;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _screens = [
-      const Scaffold(body: Center(child: Text("Home Page"))),
-      const Scaffold(body: Center(child: Text("Lost Items Page"))),
-      _FoundTab(),
-      const Scaffold(body: Center(child: Text("Profile Page"))),
-    ];
-  }
 
   void _onBottomNavTap(int index) {
     if (_selectedIndex == index) return;
 
-    setState(() {
-      _selectedIndex = index;
-    });
+    setState(() => _selectedIndex = index);
 
     switch (index) {
       case 0:
-        AppRoutes.goTo(context, AppRoutes.home);
+        Navigator.pushReplacementNamed(context, AppRoutes.home);
         break;
       case 1:
-        AppRoutes.goTo(context, AppRoutes.lostItems);
+        Navigator.pushReplacementNamed(context, AppRoutes.lostItems);
         break;
       case 2:
-        // Already here
         break;
       case 3:
-        AppRoutes.goTo(context, AppRoutes.profile);
+        Navigator.pushReplacementNamed(context, AppRoutes.profile);
         break;
     }
   }
@@ -52,7 +36,7 @@ class _FoundItemsScreenState extends State<FoundItemsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: IndexedStack(index: _selectedIndex, children: _screens),
+      body: const _FoundTab(),
       bottomNavigationBar: AppNavigationBar(
         selectedIndex: _selectedIndex,
         onTap: _onBottomNavTap,
@@ -61,12 +45,15 @@ class _FoundItemsScreenState extends State<FoundItemsScreen> {
   }
 }
 
+// FOUND TAB
+
 class _FoundTab extends StatelessWidget {
+  const _FoundTab();
+
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        // HEADER (same as lost)
         Container(
           color: const Color(0xFF1F3C88),
           padding: const EdgeInsets.only(
@@ -77,10 +64,7 @@ class _FoundTab extends StatelessWidget {
           ),
           child: Row(
             children: [
-              IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.white),
-                onPressed: () => Navigator.pop(context),
-              ),
+              const SizedBox(width: 48),
               const Expanded(
                 child: Text(
                   "Found Items",
@@ -126,8 +110,10 @@ class _FoundTab extends StatelessWidget {
                   children: [
                     Expanded(
                       child: GestureDetector(
-                        onTap: () =>
-                            AppRoutes.goTo(context, AppRoutes.lostItems),
+                        onTap: () => Navigator.pushReplacementNamed(
+                          context,
+                          AppRoutes.lostItems,
+                        ),
                         child: Container(
                           padding: const EdgeInsets.symmetric(vertical: 14),
                           decoration: BoxDecoration(
@@ -171,7 +157,6 @@ class _FoundTab extends StatelessWidget {
 
                 const SizedBox(height: 20),
 
-                // CARD
                 _FoundItemCard(),
               ],
             ),
@@ -181,6 +166,8 @@ class _FoundTab extends StatelessWidget {
     );
   }
 }
+
+// ITEM CARD
 
 class _FoundItemCard extends StatelessWidget {
   @override
@@ -259,13 +246,12 @@ class _FoundItemCard extends StatelessWidget {
 
                 const SizedBox(height: 8),
 
-                // BUTTON
                 GestureDetector(
                   onTap: () {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => FoundItemDetailsScreen(),
+                        builder: (context) => const FoundItemDetailsScreen(),
                       ),
                     );
                   },

--- a/campus_lost_found_app/lib/features/home/screens/home_screen.dart
+++ b/campus_lost_found_app/lib/features/home/screens/home_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import '../../../features/profile/screens/profile_screen.dart';
 import '../../../widgets/navigation_bar.dart';
 import '../../../routes/app_routes.dart';
 
@@ -21,13 +20,6 @@ class _HomeScreenState extends State<HomeScreen>
   late Animation<double> _fadeAnimation;
 
   int _selectedIndex = 0;
-
-  final List<Widget> _screens = [
-    const SizedBox(),
-    const Scaffold(body: Center(child: Text("Lost Items Page"))),
-    const Scaffold(body: Center(child: Text("Found Items Page"))),
-    const ProfilePage(),
-  ];
 
   @override
   void initState() {
@@ -68,7 +60,6 @@ class _HomeScreenState extends State<HomeScreen>
 
     setState(() {
       userName = name;
-      _screens[0] = _HomeTab(userName: userName);
       _loaded = true;
     });
 
@@ -76,20 +67,22 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   void _onBottomNavTap(int index) {
+    if (index == _selectedIndex) return;
+
     setState(() => _selectedIndex = index);
 
     switch (index) {
       case 0:
-        // Already here
+        Navigator.pushReplacementNamed(context, AppRoutes.home);
         break;
       case 1:
-        AppRoutes.goTo(context, AppRoutes.lostItems);
+        Navigator.pushReplacementNamed(context, AppRoutes.lostItems);
         break;
       case 2:
-        AppRoutes.goTo(context, AppRoutes.foundItems);
+        Navigator.pushReplacementNamed(context, AppRoutes.foundItems);
         break;
       case 3:
-        AppRoutes.goTo(context, AppRoutes.profile);
+        Navigator.pushReplacementNamed(context, AppRoutes.profile);
         break;
     }
   }
@@ -109,7 +102,7 @@ class _HomeScreenState extends State<HomeScreen>
     return FadeTransition(
       opacity: _fadeAnimation,
       child: Scaffold(
-        body: IndexedStack(index: _selectedIndex, children: _screens),
+        body: _HomeTab(userName: userName),
         bottomNavigationBar: AppNavigationBar(
           selectedIndex: _selectedIndex,
           onTap: _onBottomNavTap,
@@ -142,14 +135,7 @@ class _HomeTab extends StatelessWidget {
           ),
           child: Row(
             children: [
-              IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.white),
-                onPressed: () {
-                  if (Navigator.canPop(context)) {
-                    Navigator.pop(context);
-                  }
-                },
-              ),
+              const SizedBox(width: 48),
               const Expanded(
                 child: Text(
                   "Campus Lost & Found",
@@ -166,7 +152,6 @@ class _HomeTab extends StatelessWidget {
           ),
         ),
 
-        /// BODY
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16),
@@ -183,7 +168,6 @@ class _HomeTab extends StatelessWidget {
 
                 const SizedBox(height: 20),
 
-                /// PRIMARY CARDS
                 _PrimaryCard(
                   height: height * 0.16,
                   color: const Color(0xFF254EBA),
@@ -206,7 +190,6 @@ class _HomeTab extends StatelessWidget {
 
                 const SizedBox(height: 24),
 
-                // SECONDARY CARDS
                 _SecondaryCard(
                   height: height * 0.11,
                   icon: "assets/icons/view_lost_items.png",

--- a/campus_lost_found_app/lib/features/lost_items/screens/lost_items_list_screen.dart
+++ b/campus_lost_found_app/lib/features/lost_items/screens/lost_items_list_screen.dart
@@ -1,45 +1,18 @@
-// File: lib/features/lost_items/screens/lost_items_list_screen.dart
 import 'package:flutter/material.dart';
 import 'lost_item_details_screen.dart';
 import '../../../widgets/navigation_bar.dart';
 import '../../../routes/app_routes.dart';
 
-class LostItemsScreen extends StatefulWidget {
+class LostItemsScreen extends StatelessWidget {
   const LostItemsScreen({super.key});
 
-  @override
-  _LostItemsScreenState createState() => _LostItemsScreenState();
-}
-
-class _LostItemsScreenState extends State<LostItemsScreen> {
-  int _selectedIndex = 1; // Lost tab index
-  late final List<Widget> _screens;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _screens = [
-      const Scaffold(body: Center(child: Text("Home Page"))),
-      _LostTab(),
-      const Scaffold(body: Center(child: Text("Found Items Page"))),
-      const Scaffold(body: Center(child: Text("Profile Page"))),
-    ];
-  }
-
-  void _onBottomNavTap(int index) {
-    if (_selectedIndex == index) return;
-
-    setState(() {
-      _selectedIndex = index;
-    });
-
+  void _onBottomNavTap(BuildContext context, int index) {
     switch (index) {
       case 0:
         AppRoutes.goTo(context, AppRoutes.home);
         break;
       case 1:
-        // Already here
+        // Already on Lost screen
         break;
       case 2:
         AppRoutes.goTo(context, AppRoutes.foundItems);
@@ -53,22 +26,25 @@ class _LostItemsScreenState extends State<LostItemsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: IndexedStack(index: _selectedIndex, children: _screens),
+      body: const _LostTab(),
+
       bottomNavigationBar: AppNavigationBar(
-        selectedIndex: _selectedIndex,
-        onTap: _onBottomNavTap,
+        selectedIndex: 1, // Lost tab active
+        onTap: (index) => _onBottomNavTap(context, index),
       ),
     );
   }
 }
 
-// Lost Tab Widget
+// LOST TAB
+
 class _LostTab extends StatelessWidget {
+  const _LostTab();
+
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        // Header
         Container(
           color: const Color(0xFF1F3C88),
           padding: const EdgeInsets.only(
@@ -79,19 +55,16 @@ class _LostTab extends StatelessWidget {
           ),
           child: Row(
             children: [
-              IconButton(
-                icon: const Icon(Icons.arrow_back, color: Colors.white),
-                onPressed: () => Navigator.pop(context),
-              ),
+              const SizedBox(width: 48),
               const Expanded(
                 child: Text(
                   "Lost Items",
+                  textAlign: TextAlign.center,
                   style: TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.w600,
                     fontSize: 18,
                   ),
-                  textAlign: TextAlign.center,
                 ),
               ),
               const SizedBox(width: 48),
@@ -104,7 +77,6 @@ class _LostTab extends StatelessWidget {
             padding: const EdgeInsets.all(16),
             child: Column(
               children: [
-                // Search Box
                 Container(
                   decoration: BoxDecoration(
                     color: Colors.white,
@@ -115,7 +87,6 @@ class _LostTab extends StatelessWidget {
                     style: TextStyle(fontWeight: FontWeight.bold),
                     decoration: InputDecoration(
                       hintText: "Search Items...",
-                      hintStyle: TextStyle(fontWeight: FontWeight.bold),
                       prefixIcon: Icon(Icons.search),
                       border: InputBorder.none,
                       contentPadding: EdgeInsets.symmetric(vertical: 14),
@@ -124,7 +95,6 @@ class _LostTab extends StatelessWidget {
                 ),
 
                 const SizedBox(height: 16),
-
                 Row(
                   children: [
                     Expanded(
@@ -163,10 +133,7 @@ class _LostTab extends StatelessWidget {
                           child: const Center(
                             child: Text(
                               "Found Items",
-                              style: TextStyle(
-                                color: Colors.black87,
-                                fontWeight: FontWeight.w600,
-                              ),
+                              style: TextStyle(fontWeight: FontWeight.w600),
                             ),
                           ),
                         ),
@@ -176,8 +143,8 @@ class _LostTab extends StatelessWidget {
                 ),
 
                 const SizedBox(height: 20),
-
-                _LostItemCard(),
+                // ITEM CARD
+                const _LostItemCard(),
               ],
             ),
           ),
@@ -187,8 +154,11 @@ class _LostTab extends StatelessWidget {
   }
 }
 
-// Lost Item Card
+// LOST ITEM CARD
+
 class _LostItemCard extends StatelessWidget {
+  const _LostItemCard();
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -274,7 +244,7 @@ class _LostItemCard extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => LostItemDetailsScreen(),
+                        builder: (_) => const LostItemDetailsScreen(),
                       ),
                     );
                   },

--- a/campus_lost_found_app/lib/features/profile/screens/profile_screen.dart
+++ b/campus_lost_found_app/lib/features/profile/screens/profile_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import '../../../routes/app_routes.dart';
 import '../../../widgets/navigation_bar.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -16,6 +17,8 @@ class _ProfilePageState extends State<ProfilePage> {
   String name = "User";
   String imageBase64 = "";
   bool isLoading = true;
+
+  int _selectedIndex = 3;
 
   Future<void> loadUserData() async {
     final user = FirebaseAuth.instance.currentUser;
@@ -37,7 +40,7 @@ class _ProfilePageState extends State<ProfilePage> {
         }
       }
     } catch (e) {
-      // Silently handle error loading user data
+      // Handling error
     }
 
     setState(() {
@@ -51,18 +54,22 @@ class _ProfilePageState extends State<ProfilePage> {
     loadUserData();
   }
 
-  void _onNavTap(int index) {
-    if (index == 3) return;
+  void _onBottomNavTap(int index) {
+    if (index == _selectedIndex) return;
+
+    setState(() => _selectedIndex = index);
 
     switch (index) {
       case 0:
-        Navigator.pushReplacementNamed(context, '/home');
+        Navigator.pushReplacementNamed(context, AppRoutes.home);
         break;
       case 1:
-        Navigator.pushReplacementNamed(context, '/lost');
+        Navigator.pushReplacementNamed(context, AppRoutes.lostItems);
         break;
       case 2:
-        Navigator.pushReplacementNamed(context, '/found');
+        Navigator.pushReplacementNamed(context, AppRoutes.foundItems);
+        break;
+      case 3:
         break;
     }
   }
@@ -74,12 +81,11 @@ class _ProfilePageState extends State<ProfilePage> {
     }
 
     return Scaffold(
-      backgroundColor: const Color(0xFF254EBA),
+      backgroundColor: const Color(0xFF1F3C88),
       body: Column(
         children: [
           const SizedBox(height: 60),
 
-          // Profile Picture with Camera Icon (UI SAME)
           Stack(
             children: [
               CircleAvatar(
@@ -136,7 +142,6 @@ class _ProfilePageState extends State<ProfilePage> {
 
           const SizedBox(height: 30),
 
-          // bottom card (UI SAME)
           Expanded(
             child: Container(
               width: double.infinity,
@@ -147,23 +152,12 @@ class _ProfilePageState extends State<ProfilePage> {
               ),
               child: Column(
                 children: [
-                  _menuTile(
-                    Icons.description_outlined,
-                    "My Reports",
-                    style: const TextStyle(color: Colors.black),
-                  ),
+                  _menuTile(Icons.description_outlined, "My Reports"),
                   const Divider(),
-
-                  _menuTile(
-                    Icons.lock_outline,
-                    "Change Password",
-                    style: const TextStyle(color: Colors.black),
-                  ),
+                  _menuTile(Icons.lock_outline, "Change Password"),
                   const Divider(),
-
                   _notificationTile(),
                   const Divider(),
-
                   _logoutTile(context),
                 ],
               ),
@@ -172,17 +166,20 @@ class _ProfilePageState extends State<ProfilePage> {
         ],
       ),
 
-      bottomNavigationBar: AppNavigationBar(selectedIndex: 3, onTap: _onNavTap),
+      bottomNavigationBar: AppNavigationBar(
+        selectedIndex: _selectedIndex,
+        onTap: _onBottomNavTap,
+      ),
     );
   }
 
-  Widget _menuTile(IconData icon, String text, {TextStyle? style}) {
+  Widget _menuTile(IconData icon, String text) {
     return ListTile(
       leading: CircleAvatar(
         backgroundColor: const Color(0xFFE6ECFF),
         child: Icon(icon, color: const Color(0xFF2F4FB2)),
       ),
-      title: Text(text, style: style),
+      title: Text(text, style: const TextStyle(color: Colors.black)),
       trailing: const Icon(Icons.arrow_forward_ios, size: 16),
     );
   }
@@ -226,6 +223,7 @@ class _ProfilePageState extends State<ProfilePage> {
 
   void _showLogoutDialog(BuildContext context) {
     final navigator = Navigator.of(context);
+
     showDialog(
       context: context,
       builder: (context) {
@@ -249,7 +247,6 @@ class _ProfilePageState extends State<ProfilePage> {
                   navigator.pushNamedAndRemoveUntil('/login', (route) => false);
                 },
                 style: ElevatedButton.styleFrom(
-                  textStyle: const TextStyle(color: Colors.white),
                   backgroundColor: const Color(0xFF254EBA),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(20),
@@ -262,10 +259,10 @@ class _ProfilePageState extends State<ProfilePage> {
               ),
               TextButton(
                 onPressed: () => Navigator.pop(context),
-                style: TextButton.styleFrom(
-                  foregroundColor: const Color(0xFF254EBA),
+                child: const Text(
+                  "Cancel",
+                  style: TextStyle(color: Color(0xFF254EBA)),
                 ),
-                child: const Text("Cancel"),
               ),
             ],
           ),


### PR DESCRIPTION
- Converted LostItemsScreen and FoundItemsScreen to navigator model with AppNavigationBar
- Fixed duplicate nav bars on ProfilePage and HomeScreen
- Updated bottom navigation to use proper routes and prevent stacking
- Standardized top headers, removed back buttons from Lost & Found screens
- Fixed back arrow behavior to navigate correctly without returning to unintended screens
- Cleaned up UI consistency and search/filter layout for Lost and Found items