### PR TITLE
Added Firestore integration for found item details screen

### DIFF
--- a/campus_lost_found_app/lib/features/found_items/screens/found_item_details_screen.dart
+++ b/campus_lost_found_app/lib/features/found_items/screens/found_item_details_screen.dart
@@ -1,8 +1,26 @@
 import 'package:flutter/material.dart';
 import '../../../routes/app_routes.dart';
+import 'dart:convert';
 
 class FoundItemDetailsScreen extends StatefulWidget {
-  const FoundItemDetailsScreen({super.key});
+  final String itemName;
+  final String location;
+  final String date;
+  final String time;
+  final String category;
+  final String description;
+  final String imageBase64;
+
+  const FoundItemDetailsScreen({
+    super.key,
+    required this.itemName,
+    required this.location,
+    required this.date,
+    required this.time,
+    required this.category,
+    required this.description,
+    required this.imageBase64,
+  });
 
   @override
   State<FoundItemDetailsScreen> createState() => FoundItemDetailsScreenState();
@@ -10,11 +28,6 @@ class FoundItemDetailsScreen extends StatefulWidget {
 
 class FoundItemDetailsScreenState extends State<FoundItemDetailsScreen> {
   bool isExpanded = false;
-
-  final String description =
-      "A USB drive containing important documents and personal files. "
-      "It was found in the computer lab and might belong to a student or faculty member. "
-      "Contains important assignments, notes, and software installation files.";
 
   @override
   Widget build(BuildContext context) {
@@ -46,10 +59,9 @@ class FoundItemDetailsScreenState extends State<FoundItemDetailsScreen> {
             SizedBox(
               width: double.infinity,
               height: 300,
-              child: Image.asset(
-                'assets/images/usb.jpg',
-                fit: BoxFit.cover,
-                alignment: const Alignment(0, 0.7),
+              child: Image.memory(
+                base64Decode(widget.imageBase64),
+                fit: BoxFit.fill,
               ),
             ),
             Container(
@@ -64,8 +76,8 @@ class FoundItemDetailsScreenState extends State<FoundItemDetailsScreen> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      const Text(
-                        "USB Drive",
+                      Text(
+                        widget.itemName,
                         style: TextStyle(
                           fontSize: 22,
                           fontWeight: FontWeight.bold,
@@ -92,17 +104,14 @@ class FoundItemDetailsScreenState extends State<FoundItemDetailsScreen> {
                     ],
                   ),
                   const SizedBox(height: 16),
-                  infoRow(
-                    Icons.location_on,
-                    "Location:  Computer Lab  FOC L104",
-                  ),
+                  infoRow(Icons.location_on, "Location: ${widget.location}"),
                   const SizedBox(height: 10),
                   infoRow(
                     Icons.calendar_today,
-                    "Date & Time:  29 Jan 2026, around 4:10 PM",
+                    "Found on: ${widget.date} at ${widget.time}",
                   ),
                   const SizedBox(height: 10),
-                  infoRow(Icons.grid_view, "Category:  Electronic"),
+                  infoRow(Icons.grid_view, "Category: ${widget.category}"),
                   const SizedBox(height: 18),
                   const Text(
                     "Description:",
@@ -110,7 +119,7 @@ class FoundItemDetailsScreenState extends State<FoundItemDetailsScreen> {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    description,
+                    widget.description,
                     maxLines: isExpanded ? null : 2,
                     overflow: isExpanded
                         ? TextOverflow.visible

--- a/campus_lost_found_app/lib/features/found_items/screens/found_items_list_screen.dart
+++ b/campus_lost_found_app/lib/features/found_items/screens/found_items_list_screen.dart
@@ -221,7 +221,7 @@ class _FoundItemCard extends StatelessWidget {
               ),
               child: Row(
                 children: [
-                  // IMAGE (UPDATED WITH YOUR CODE)
+                  
                   Container(
                     height: 70,
                     width: 70,
@@ -231,7 +231,8 @@ class _FoundItemCard extends StatelessWidget {
                     ),
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(10),
-                      child: (imageBase64 != null &&
+                      child:
+                          (imageBase64 != null &&
                               imageBase64.toString().isNotEmpty)
                           ? Image.memory(
                               base64Decode(imageBase64),
@@ -244,7 +245,7 @@ class _FoundItemCard extends StatelessWidget {
 
                   const SizedBox(width: 12),
 
-                  // TEXT CONTENT
+                  
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -261,8 +262,11 @@ class _FoundItemCard extends StatelessWidget {
 
                         Row(
                           children: [
-                            const Icon(Icons.location_on,
-                                size: 14, color: Colors.grey),
+                            const Icon(
+                              Icons.location_on,
+                              size: 14,
+                              color: Colors.grey,
+                            ),
                             const SizedBox(width: 4),
                             Expanded(
                               child: Text(
@@ -280,8 +284,11 @@ class _FoundItemCard extends StatelessWidget {
 
                         Row(
                           children: [
-                            const Icon(Icons.calendar_today,
-                                size: 14, color: Colors.grey),
+                            const Icon(
+                              Icons.calendar_today,
+                              size: 14,
+                              color: Colors.grey,
+                            ),
                             const SizedBox(width: 4),
                             Text(
                               "Found on: $date, $time",
@@ -300,8 +307,15 @@ class _FoundItemCard extends StatelessWidget {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                builder: (context) =>
-                                    const FoundItemDetailsScreen(),
+                                builder: (context) => FoundItemDetailsScreen(
+                                  itemName: itemName,
+                                  location: location,
+                                  date: date,
+                                  time: time,
+                                  category: data['category'] ?? "",
+                                  description: data['description'] ?? "",
+                                  imageBase64: imageBase64,
+                                ),
                               ),
                             );
                           },


### PR DESCRIPTION

Updated the Found Item Details Screen to load and display dynamic item data from Firestore when a user clicks "View Details" on the found items list. Added parameters to FoundItemDetailsScreen to receive:

item name
location
date
time
category
description
image

Replaced hardcoded values with Firestore data,
Displayed uploaded item image using Image.memory(base64Decode()),
Combined date and time into one field in the details screen,
Kept the existing UI, navigation, and routing unchanged,
Added expandable description functionality using See More,
Preserved the Contact Founder button behavior,