### PR TITLE
resolve state loss and category selection flow by correcting navigati…

### DIFF
--- a/campus_lost_found_app/lib/features/ai_features/screens/lost_deleted_succesfully.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/lost_deleted_succesfully.dart
@@ -35,7 +35,14 @@ class LostDeletedSucces extends StatelessWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pushNamed(context, AppRoutes.lostSelectCategory);
+                    Navigator.pushNamed(
+                      context,
+                      AppRoutes.lostSelectCategory,
+                    ).then((value) {
+                      if (value != null) {
+                        Navigator.pop(context, value);
+                      }
+                    });
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Color(0xFF254EBA),

--- a/campus_lost_found_app/lib/features/ai_features/screens/lost_select_category_page.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/lost_select_category_page.dart
@@ -96,14 +96,10 @@ class LostSelectCategoryPageState extends State<LostSelectCategoryPage> {
         padding: const EdgeInsets.all(16),
         child: ElevatedButton(
           onPressed: () {
-         if (selectedCategory.isNotEmpty) {
-              Navigator.pushNamed(
-              context,
-              AppRoutes.reportLostItem,
-            arguments: selectedCategory,
-              );
-                }
-              },
+            if (selectedCategory.isNotEmpty) {
+              Navigator.pop(context, selectedCategory);
+            }
+          },
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color(0xFF254EBA),
             shape: RoundedRectangleBorder(

--- a/campus_lost_found_app/lib/features/ai_features/screens/lost_selected_succesfully.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/lost_selected_succesfully.dart
@@ -34,7 +34,7 @@ class LostSelectedSuccess extends StatelessWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pushNamed(context, AppRoutes.reportLostItem);
+                    Navigator.pop(context);
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Color(0xFF254EBA),

--- a/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
+++ b/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
@@ -7,7 +7,6 @@ import 'package:google_mlkit_image_labeling/google_mlkit_image_labeling.dart';
 import '../../../routes/app_routes.dart';
 import '../../ai_features/screens/lost_ai_image_generator_screen.dart';
 
-
 class ReportLostItemScreen extends StatefulWidget {
   const ReportLostItemScreen({super.key});
 
@@ -25,6 +24,18 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
   String detectedCategory = "Detecting...";
   TextEditingController dateController = TextEditingController();
   TextEditingController timeController = TextEditingController();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args != null && manualCategory == null) {
+      setState(() {
+        manualCategory = args as String;
+        detectedCategory = manualCategory!;
+      });
+    }
+  }
 
   Widget inputField(
     String title, {
@@ -132,12 +143,6 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final args = ModalRoute.of(context)?.settings.arguments;
-
-       if (args != null && manualCategory == null) {
-          manualCategory = args as String;
-          detectedCategory = manualCategory!; 
-         }
     return Scaffold(
       backgroundColor: Colors.grey[200],
       appBar: AppBar(
@@ -199,12 +204,12 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
                       });
 
                       if (manualCategory == null) {
-                       String detected = await detectCategory(image);
+                        String detected = await detectCategory(image);
 
-                      setState(() {
-                      detectedCategory = detected;
-                     });
-                    }
+                        setState(() {
+                          detectedCategory = detected;
+                        });
+                      }
                     }
                   },
                   borderRadius: BorderRadius.circular(12),
@@ -297,11 +302,18 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
                         width: 110,
                         height: 40,
                         child: ElevatedButton(
-                          onPressed: () {
-                            Navigator.pushNamed(
+                          onPressed: () async {
+                            final result = await Navigator.pushNamed(
                               context,
                               AppRoutes.lostdeletedSSuccess,
                             );
+
+                            if (result != null) {
+                              setState(() {
+                                manualCategory = result as String;
+                                detectedCategory = manualCategory!;
+                              });
+                            }
                           },
                           style: ElevatedButton.styleFrom(
                             backgroundColor: Colors.grey,


### PR DESCRIPTION
…on handling

- Fixed form data reset issue in Report Lost Item screen
- Replaced incorrect navigation (pushNamed) with pop-based flow to preserve state
- Implemented proper data return using Navigator.pop with result
- Updated delete → category selection → return flow to correctly pass selected category
- Ensured detected/manual category updates without rebuilding screen
- Maintained existing UI and logic while fixing navigation behavior