### PR TITLE
resolve state loss and category selection flow by correcting navigati…

### DIFF
--- a/campus_lost_found_app/lib/features/ai_features/screens/found_deleted_succesfully.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/found_deleted_succesfully.dart
@@ -35,7 +35,14 @@ class FoundDeletedSucces extends StatelessWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pushNamed(context, AppRoutes.foundSelectCategory);
+                    Navigator.pushNamed(
+                      context,
+                      AppRoutes.foundSelectCategory,
+                    ).then((value) {
+                      if (value != null) {
+                        Navigator.pop(context, value);
+                      }
+                    });
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Color.fromARGB(255, 236, 122, 60),

--- a/campus_lost_found_app/lib/features/ai_features/screens/found_select_category_page.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/found_select_category_page.dart
@@ -98,12 +98,8 @@ class _FoundSelectCategoryPageState extends State<FoundSelectCategoryPage> {
         child: ElevatedButton(
           onPressed: () {
             if (selectedCategory.isNotEmpty) {
-              Navigator.pushNamed(
-              context,
-              AppRoutes.reportFoundItem,
-            arguments: selectedCategory,
-              );
-              }
+              Navigator.pop(context, selectedCategory);
+            }
           },
           style: ElevatedButton.styleFrom(
             backgroundColor: const Color.fromARGB(255, 236, 122, 60),

--- a/campus_lost_found_app/lib/features/ai_features/screens/found_selected_succesfully.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/found_selected_succesfully.dart
@@ -34,7 +34,7 @@ class FoundSelectedSuccess extends StatelessWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pushNamed(context, AppRoutes.reportFoundItem);
+                    Navigator.pop(context);
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Color.fromARGB(255, 236, 122, 60),

--- a/campus_lost_found_app/lib/features/found_items/screens/report_found_item_screen.dart
+++ b/campus_lost_found_app/lib/features/found_items/screens/report_found_item_screen.dart
@@ -24,6 +24,18 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
   File? selectedImage;
   String detectedCategory = "Detecting...";
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args != null && manualCategory == null) {
+      setState(() {
+        manualCategory = args as String;
+        detectedCategory = manualCategory!;
+      });
+    }
+  }
+
   Widget inputField(
     String title, {
     int maxLines = 1,
@@ -130,12 +142,6 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
 
   @override
   Widget build(BuildContext context) {
-    final args = ModalRoute.of(context)?.settings.arguments;
-
-       if (args != null && manualCategory == null) {
-          manualCategory = args as String;
-          detectedCategory = manualCategory!; 
-         }
     return Scaffold(
       backgroundColor: Colors.grey[200],
       appBar: AppBar(
@@ -196,12 +202,12 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                       });
 
                       if (manualCategory == null) {
-                       String detected = await detectCategory(image);
+                        String detected = await detectCategory(image);
 
-                      setState(() {
-                           detectedCategory = detected;
-                           });
-                       }
+                        setState(() {
+                          detectedCategory = detected;
+                        });
+                      }
                     }
                   },
                   borderRadius: BorderRadius.circular(12),
@@ -298,11 +304,18 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                         width: 110,
                         height: 40,
                         child: ElevatedButton(
-                          onPressed: () {
-                            Navigator.pushNamed(
+                          onPressed: () async {
+                            final result = await Navigator.pushNamed(
                               context,
                               AppRoutes.foundDeletedSuccess,
                             );
+
+                            if (result != null) {
+                              setState(() {
+                                manualCategory = result as String;
+                                detectedCategory = manualCategory!;
+                              });
+                            }
                           },
                           style: ElevatedButton.styleFrom(
                             backgroundColor: Colors.grey,
@@ -365,9 +378,9 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                     Navigator.pushNamed(context, AppRoutes.foundItemSubmit);
                   } catch (e) {
                     if (!mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text("Error: $e")),
-                    );
+                    ScaffoldMessenger.of(
+                      context,
+                    ).showSnackBar(SnackBar(content: Text("Error: $e")));
                   }
                 },
                 style: ElevatedButton.styleFrom(


### PR DESCRIPTION
…on handling

- Fixed form data reset issue in Report Found Item screen
- Replaced incorrect navigation (pushNamed) with pop-based flow to preserve state
- Implemented proper data return using Navigator.pop with result
- Updated delete → category selection → return flow to correctly pass selected category
- Ensured detected/manual category updates without rebuilding screen
- Maintained existing UI and logic while fixing navigation behavior