### PR TITLE
Upgrade found items module - Fix image size issue and add preview

### DIFF
--- a/campus_lost_found_app/lib/features/ai_features/screens/found_ai_generated_image_screen.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/found_ai_generated_image_screen.dart
@@ -1,7 +1,11 @@
+import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:stability_image_generation/stability_image_generation.dart';
-import 'found_image_picker.dart'; 
+import 'package:path_provider/path_provider.dart';
+import 'package:image/image.dart' as img;
+import 'package:logger/logger.dart';
 
 class FoundAIGeneratedImageScreen extends StatefulWidget {
   final String description;
@@ -16,12 +20,15 @@ class FoundAIGeneratedImageScreen extends StatefulWidget {
 class _FoundAIGeneratedImageScreenState
     extends State<FoundAIGeneratedImageScreen> {
   final StabilityAI _ai = StabilityAI();
+  final Logger _logger = Logger();
 
   final String apiKey = 'sk-iLvm6WNnhkgitWZE0gP2THVovoW9cLh3RFAClwHZBv9Mq06H';
   final ImageAIStyle imageAIStyle = ImageAIStyle.digitalPainting;
 
   Uint8List? imageBytes;
   bool isLoading = true;
+  String? errorMessage;
+  File? convertedFile;
 
   @override
   void initState() {
@@ -29,24 +36,105 @@ class _FoundAIGeneratedImageScreenState
     generate();
   }
 
+  Future<File?> _convertAndCompressImage(Uint8List bytes) async {
+    try {
+      if (bytes.isEmpty) {
+        throw Exception("Image bytes are empty");
+      }
+
+      // Try to decode the image to validate it
+      img.Image? decodedImage = img.decodeImage(bytes);
+      if (decodedImage == null) {
+        throw Exception("Invalid image format");
+      }
+
+      // Resize image if too large (max dimension 800px)
+      int width = decodedImage.width;
+      int height = decodedImage.height;
+
+      if (width > 800 || height > 800) {
+        if (width > height) {
+          height = (height * 800 / width).round();
+          width = 800;
+        } else {
+          width = (width * 800 / height).round();
+          height = 800;
+        }
+        decodedImage = img.copyResize(
+          decodedImage,
+          width: width,
+          height: height,
+        );
+      }
+
+      // Compress image with quality (60% quality)
+      final compressedBytes = img.encodeJpg(decodedImage, quality: 60);
+
+      // Check file size and compress more if needed
+      int fileSize = compressedBytes.length;
+      int quality = 60;
+
+      while (fileSize > 500000 && quality > 20) {
+        quality -= 10;
+        final recompressed = img.encodeJpg(decodedImage, quality: quality);
+        fileSize = recompressed.length;
+      }
+
+      final finalBytes = fileSize < compressedBytes.length
+          ? img.encodeJpg(decodedImage, quality: quality)
+          : compressedBytes;
+
+      final tempDir = await getTemporaryDirectory();
+      final file = File(
+        '${tempDir.path}/generated_image_${DateTime.now().millisecondsSinceEpoch}.jpg',
+      );
+      await file.writeAsBytes(finalBytes);
+
+      if (await file.exists() && await file.length() > 0) {
+        _logger.i("Final image size: ${await file.length()} bytes");
+        return file;
+      } else {
+        throw Exception("Failed to create valid image file");
+      }
+    } catch (e) {
+      _logger.e("Error converting image: $e");
+      return null;
+    }
+  }
+
   Future<void> generate() async {
     try {
+      setState(() {
+        errorMessage = null;
+        isLoading = true;
+      });
+
       Uint8List result = await _ai.generateImage(
         apiKey: apiKey,
         imageAIStyle: imageAIStyle,
         prompt: widget.description,
       );
 
-      setState(() {
-        imageBytes = result;
-        isLoading = false;
-      });
-    } catch (e) {
-      if (kDebugMode) {
-        print("Error: $e");
+      if (result.isEmpty) {
+        throw Exception("Generated image is empty");
       }
+
+      final file = await _convertAndCompressImage(result);
+
+      if (file != null) {
+        setState(() {
+          imageBytes = result;
+          convertedFile = file;
+          isLoading = false;
+        });
+      } else {
+        throw Exception("Failed to save image");
+      }
+    } catch (e) {
+      _logger.e("Error generating image: $e");
       setState(() {
         isLoading = false;
+        errorMessage = "Failed to generate image: $e";
       });
     }
   }
@@ -55,7 +143,6 @@ class _FoundAIGeneratedImageScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-
       appBar: AppBar(
         backgroundColor: const Color(0xFF1F3C88),
         centerTitle: true,
@@ -69,8 +156,13 @@ class _FoundAIGeneratedImageScreenState
             color: Colors.white,
           ),
         ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
       ),
-
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -80,11 +172,8 @@ class _FoundAIGeneratedImageScreenState
               "AI Generated Image",
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
-
             Text(widget.description, style: const TextStyle(fontSize: 16)),
-
             const SizedBox(height: 20),
-
             Container(
               height: 250,
               width: double.infinity,
@@ -95,45 +184,88 @@ class _FoundAIGeneratedImageScreenState
               child: Center(
                 child: isLoading
                     ? const CircularProgressIndicator()
-                    : imageBytes != null
-                        ? ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child:
-                                Image.memory(imageBytes!, fit: BoxFit.cover),
-                          )
-                        : const Icon(Icons.error),
+                    : errorMessage != null
+                    ? Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Icon(Icons.error, size: 50, color: Colors.red),
+                          const SizedBox(height: 10),
+                          Text(
+                            errorMessage!,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(color: Colors.red),
+                          ),
+                        ],
+                      )
+                    : convertedFile != null
+                    ? ClipRRect(
+                        borderRadius: BorderRadius.circular(12),
+                        child: Image.file(convertedFile!, fit: BoxFit.cover),
+                      )
+                    : const Icon(Icons.error),
               ),
             ),
-
             const Spacer(),
-
-            SizedBox(
-              width: double.infinity,
-              height: 50,
-              child: ElevatedButton(
-                onPressed: () {
-                  if (imageBytes != null) {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) =>
-                            FoundImagePicker(imageBytes: imageBytes), 
-                      ),
-                    );
-                  }
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color.fromARGB(255, 236, 122, 60),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
+            if (errorMessage == null && !isLoading && convertedFile != null)
+              SizedBox(
+                width: double.infinity,
+                height: 50,
+                child: ElevatedButton(
+                  onPressed: () async {
+                    if (convertedFile != null &&
+                        await convertedFile!.exists()) {
+                      if (context.mounted) {
+                        Navigator.pop(context, convertedFile);
+                        Navigator.pop(context, convertedFile);
+                      }
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text(
+                            "Image file is not valid. Please try again.",
+                          ),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color.fromARGB(255, 236, 122, 60),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: const Text(
+                    "Use this Image",
+                    style: TextStyle(fontSize: 16, color: Colors.white),
                   ),
                 ),
-                child: const Text(
-                  "Use this Image",
-                  style: TextStyle(fontSize: 16, color: Colors.white),
+              ),
+            if (errorMessage != null)
+              SizedBox(
+                width: double.infinity,
+                height: 50,
+                child: ElevatedButton(
+                  onPressed: () {
+                    setState(() {
+                      isLoading = true;
+                      errorMessage = null;
+                      convertedFile = null;
+                    });
+                    generate();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color.fromARGB(255, 236, 122, 60),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: const Text(
+                    "Retry",
+                    style: TextStyle(fontSize: 16, color: Colors.white),
+                  ),
                 ),
               ),
-            ),
           ],
         ),
       ),

--- a/campus_lost_found_app/lib/features/ai_features/screens/found_ai_image_generator_screen.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/found_ai_image_generator_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'found_ai_generated_image_screen.dart';
 
@@ -19,7 +20,7 @@ class _FoundAIImageGeneratorScreenState
     super.dispose();
   }
 
-  void generateImage() {
+  void generateImage() async {
     final description = _descriptionController.text.trim();
 
     if (description.isEmpty) {
@@ -29,13 +30,17 @@ class _FoundAIImageGeneratorScreenState
       return;
     }
 
-    Navigator.push(
+    final result = await Navigator.push(
       context,
       MaterialPageRoute(
         builder: (context) =>
             FoundAIGeneratedImageScreen(description: description),
       ),
     );
+
+    if (result != null && result is File && context.mounted) {
+      Navigator.pop(context, result);
+    }
   }
 
   @override
@@ -48,15 +53,20 @@ class _FoundAIImageGeneratorScreenState
         foregroundColor: Colors.white,
         elevation: 0,
         title: const Text(
-          "AI Image Generator For Lost Item",
+          "AI Image Generator For Found Item",
           style: TextStyle(
             fontSize: 18,
             fontWeight: FontWeight.w600,
             color: Colors.white,
           ),
         ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
       ),
-
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -66,9 +76,7 @@ class _FoundAIImageGeneratorScreenState
               "Describe Found Item",
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
-
             const SizedBox(height: 16),
-
             Container(
               height: 150,
               decoration: BoxDecoration(
@@ -80,22 +88,20 @@ class _FoundAIImageGeneratorScreenState
                 maxLines: null,
                 expands: true,
                 decoration: const InputDecoration(
-                  hintText: "Description About Lost Item...",
+                  hintText: "Description About Found Item...",
                   border: InputBorder.none,
                   contentPadding: EdgeInsets.all(12),
                 ),
               ),
             ),
-
             const SizedBox(height: 30),
-
             SizedBox(
               width: double.infinity,
               height: 50,
               child: ElevatedButton(
                 onPressed: generateImage,
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Color.fromARGB(255, 236, 122, 60),
+                  backgroundColor: const Color.fromARGB(255, 236, 122, 60),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(10),
                   ),

--- a/campus_lost_found_app/lib/features/ai_features/screens/found_image_picker.dart
+++ b/campus_lost_found_app/lib/features/ai_features/screens/found_image_picker.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
-import 'dart:typed_data'; 
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import '../../../routes/app_routes.dart';
+import 'package:path_provider/path_provider.dart';
 import '../../ai_features/screens/found_ai_image_generator_screen.dart';
 
 class FoundImagePicker extends StatefulWidget {
-  final Uint8List? imageBytes; 
+  final Uint8List? imageBytes;
 
   const FoundImagePicker({super.key, this.imageBytes});
 
@@ -17,6 +17,27 @@ class FoundImagePicker extends StatefulWidget {
 class _FoundImagePickerState extends State<FoundImagePicker> {
   File? _image;
   final ImagePicker _picker = ImagePicker();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.imageBytes != null) {
+      _convertAndSetImage();
+    }
+  }
+
+  Future<void> _convertAndSetImage() async {
+    if (widget.imageBytes != null) {
+      final tempDir = await getTemporaryDirectory();
+      final file = File(
+        '${tempDir.path}/selected_image_${DateTime.now().millisecondsSinceEpoch}.png',
+      );
+      await file.writeAsBytes(widget.imageBytes!);
+      setState(() {
+        _image = file;
+      });
+    }
+  }
 
   Future<void> _pickFromGallery() async {
     final picked = await _picker.pickImage(source: ImageSource.gallery);
@@ -97,7 +118,6 @@ class _FoundImagePickerState extends State<FoundImagePicker> {
           ),
         ),
       ),
-
       body: Padding(
         padding: const EdgeInsets.all(20),
         child: Column(
@@ -119,51 +139,47 @@ class _FoundImagePickerState extends State<FoundImagePicker> {
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(12),
-                child: widget.imageBytes != null
-                    ? Image.memory(widget.imageBytes!, fit: BoxFit.cover)
-                    : _image != null
-                        ? Image.file(_image!, fit: BoxFit.cover)
-                        : const Center(child: Icon(Icons.image, size: 80)),
+                child: _image != null
+                    ? Image.file(_image!, fit: BoxFit.cover)
+                    : const Center(child: Icon(Icons.image, size: 80)),
               ),
             ),
-
             const SizedBox(height: 30),
-
             _actionCard(
               icon: Icons.image,
               title: "Choose from Gallery",
-              subtitle: "Upload real image of the lost item",
+              subtitle: "Upload real image of the found item",
               color: const Color(0xFF254EBA),
               onTap: _pickFromGallery,
             ),
-
             const SizedBox(height: 15),
-
             _actionCard(
               icon: Icons.auto_awesome,
               title: "Generate with AI",
               subtitle: "Create image from description",
               color: Colors.deepPurple,
-              onTap: () {
-                Navigator.push(
+              onTap: () async {
+                final result = await Navigator.push(
                   context,
                   MaterialPageRoute(
                     builder: (context) => const FoundAIImageGeneratorScreen(),
                   ),
                 );
+
+                if (result != null && result is File) {
+                  setState(() {
+                    _image = result;
+                  });
+                }
               },
             ),
-
             const Spacer(),
-
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: () {
-                  if (widget.imageBytes != null) {
-                    Navigator.pop(context, widget.imageBytes); 
-                  } else if (_image != null) {
-                    Navigator.pop(context, _image); 
+                  if (_image != null) {
+                    Navigator.pop(context, _image);
                   } else {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text("Please select an image")),
@@ -171,7 +187,7 @@ class _FoundImagePickerState extends State<FoundImagePicker> {
                   }
                 },
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Color.fromARGB(255, 236, 122, 60),
+                  backgroundColor: const Color.fromARGB(255, 236, 122, 60),
                   padding: const EdgeInsets.symmetric(vertical: 16),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),

--- a/campus_lost_found_app/lib/features/found_items/screens/report_found_item_screen.dart
+++ b/campus_lost_found_app/lib/features/found_items/screens/report_found_item_screen.dart
@@ -3,10 +3,13 @@ import '../../../routes/app_routes.dart';
 import '../../ai_features/screens/found_image_picker.dart';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:google_mlkit_image_labeling/google_mlkit_image_labeling.dart';
 import 'package:campus_lost_found_app/core/services/app_settings.dart';
 import 'package:campus_lost_found_app/core/services/notification_service.dart';
+import 'package:image/image.dart' as img;
+import 'package:logger/logger.dart';
 
 class ReportFoundItemPage extends StatefulWidget {
   const ReportFoundItemPage({super.key});
@@ -16,6 +19,8 @@ class ReportFoundItemPage extends StatefulWidget {
 }
 
 class ReportFoundItemPageState extends State<ReportFoundItemPage> {
+  final Logger _logger = Logger();
+
   TextEditingController dateController = TextEditingController();
   TextEditingController timeController = TextEditingController();
   TextEditingController itemController = TextEditingController();
@@ -35,6 +40,70 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
         manualCategory = args as String;
         detectedCategory = manualCategory!;
       });
+    }
+  }
+
+  @override
+  void dispose() {
+    dateController.dispose();
+    timeController.dispose();
+    itemController.dispose();
+    locationController.dispose();
+    descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<Uint8List> _compressImage(File imageFile) async {
+    try {
+      final bytes = await imageFile.readAsBytes();
+
+      // Decode the image
+      img.Image? originalImage = img.decodeImage(bytes);
+      if (originalImage == null) {
+        throw Exception("Invalid image format");
+      }
+
+      // Calculate new dimensions (max 800px)
+      int width = originalImage.width;
+      int height = originalImage.height;
+      const int maxDimension = 800;
+
+      if (width > maxDimension || height > maxDimension) {
+        if (width > height) {
+          height = (height * maxDimension / width).round();
+          width = maxDimension;
+        } else {
+          width = (width * maxDimension / height).round();
+          height = maxDimension;
+        }
+        originalImage = img.copyResize(
+          originalImage,
+          width: width,
+          height: height,
+        );
+      }
+
+      // Compress image with quality (start at 70%)
+      int quality = 70;
+      Uint8List compressedBytes = img.encodeJpg(
+        originalImage,
+        quality: quality,
+      );
+
+      // Reduce quality until file size is under 500KB or quality reaches 30%
+      while (compressedBytes.length > 500000 && quality > 30) {
+        quality -= 10;
+        compressedBytes = img.encodeJpg(originalImage, quality: quality);
+      }
+
+      _logger.i(
+        "Original size: ${bytes.length} bytes, Compressed size: ${compressedBytes.length} bytes",
+      );
+      return compressedBytes;
+    } catch (e) {
+      _logger.e("Error compressing image: $e");
+      // Return original bytes if compression fails
+      return await imageFile.readAsBytes();
     }
   }
 
@@ -140,8 +209,6 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
     return category;
   }
 
-  void uploadImage() {}
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -179,50 +246,95 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
               maxLines: 3,
               controller: descriptionController,
             ),
+
             Container(
               width: double.infinity,
-              height: 100,
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               decoration: BoxDecoration(
                 color: Colors.white,
                 borderRadius: BorderRadius.circular(12),
               ),
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(
-                  onTap: () async {
-                    final image = await Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const FoundImagePicker(),
-                      ),
-                    );
-
-                    if (image != null) {
-                      setState(() {
-                        selectedImage = image;
-                      });
-
-                      if (manualCategory == null) {
-                        String detected = await detectCategory(image);
-
-                        setState(() {
-                          detectedCategory = detected;
-                        });
-                      }
-                    }
-                  },
-                  borderRadius: BorderRadius.circular(12),
-                  child: const Padding(
-                    padding: EdgeInsets.all(12.0),
-                    child: Row(
+              child: selectedImage != null
+                  ? Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(Icons.camera_alt, size: 55),
-                        SizedBox(width: 16),
-                        Expanded(
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Image.file(
+                            selectedImage!,
+                            height: 70,
+                            width: 70,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        const Text(
+                          "Image Selected",
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        TextButton.icon(
+                          onPressed: () async {
+                            final image = await Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => const FoundImagePicker(),
+                              ),
+                            );
+                            if (image != null && image is File) {
+                              setState(() {
+                                selectedImage = image;
+                              });
+                              if (manualCategory == null) {
+                                String detected = await detectCategory(image);
+                                setState(() {
+                                  detectedCategory = detected;
+                                });
+                              }
+                            }
+                          },
+                          icon: const Icon(Icons.edit, size: 16),
+                          label: const Text(
+                            "Change Image",
+                            style: TextStyle(fontSize: 12),
+                          ),
+                          style: TextButton.styleFrom(padding: EdgeInsets.zero),
+                        ),
+                      ],
+                    )
+                  : Material(
+                      color: Colors.transparent,
+                      child: InkWell(
+                        onTap: () async {
+                          final image = await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const FoundImagePicker(),
+                            ),
+                          );
+                          if (image != null && image is File) {
+                            setState(() {
+                              selectedImage = image;
+                            });
+                            if (manualCategory == null) {
+                              String detected = await detectCategory(image);
+                              setState(() {
+                                detectedCategory = detected;
+                              });
+                            }
+                          }
+                        },
+                        borderRadius: BorderRadius.circular(12),
+                        child: const Padding(
+                          padding: EdgeInsets.all(12.0),
                           child: Column(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
+                              Icon(Icons.camera_alt, size: 55),
+                              SizedBox(height: 8),
                               Text(
                                 "Upload Image",
                                 style: TextStyle(
@@ -242,14 +354,12 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                             ],
                           ),
                         ),
-                      ],
+                      ),
                     ),
-                  ),
-                ),
-              ),
             ),
 
             const SizedBox(height: 14),
+
             Container(
               padding: const EdgeInsets.all(14),
               decoration: BoxDecoration(
@@ -360,8 +470,10 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                   }
 
                   try {
-                    final bytes = await selectedImage!.readAsBytes();
-                    String base64Image = base64Encode(bytes);
+                    final compressedBytes = await _compressImage(
+                      selectedImage!,
+                    );
+                    String base64Image = base64Encode(compressedBytes);
 
                     await FirebaseFirestore.instance
                         .collection('found_items')
@@ -375,6 +487,7 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                           'category': manualCategory ?? detectedCategory,
                           'createdAt': Timestamp.now(),
                         });
+
                     bool enabled = await AppSettings.notificationsEnabled();
 
                     if (enabled) {

--- a/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
+++ b/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
@@ -466,8 +466,11 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
                   }
 
                   try {
-                    final bytes = await selectedImage!.readAsBytes();
-                    String base64Image = base64Encode(bytes);
+                    // Use compression here
+                    final compressedBytes = await _compressImage(
+                      selectedImage!,
+                    );
+                    String base64Image = base64Encode(compressedBytes);
 
                     await FirebaseFirestore.instance
                         .collection('lost_items')


### PR DESCRIPTION
- Add image compression to fix Firestore 1MB limit (resize to 800px, compress to <500KB)
- Add image thumbnail preview (70x70) with "Image Selected" text
- Add "Change Image" button to replace selected image
- Fix AI image generation navigation flow
- Add loading states, error handling, and retry button
- Add dispose() methods to prevent memory leaks
- Replace print with Logger for production logging

Files: report_found_item_screen.dart, found_image_picker.dart, found_ai_image_generator_screen.dart, found_ai_generated_image_screen.dart