### PR TITLE
Added My Reported Items feature for Lost and Found reports.

### DIFF
--- a/campus_lost_found_app/lib/features/found_items/screens/report_found_item_screen.dart
+++ b/campus_lost_found_app/lib/features/found_items/screens/report_found_item_screen.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_mlkit_image_labeling/google_mlkit_image_labeling.dart';
 import 'package:campus_lost_found_app/core/services/app_settings.dart';
 import 'package:campus_lost_found_app/core/services/notification_service.dart';
@@ -475,6 +476,8 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                     );
                     String base64Image = base64Encode(compressedBytes);
 
+                    final user = FirebaseAuth.instance.currentUser;
+
                     await FirebaseFirestore.instance
                         .collection('found_items')
                         .add({
@@ -485,6 +488,11 @@ class ReportFoundItemPageState extends State<ReportFoundItemPage> {
                           'description': descriptionController.text,
                           'imageBase64': base64Image,
                           'category': manualCategory ?? detectedCategory,
+
+                          // IMPORTANT
+                          'userId': user!.uid,
+                          'userEmail': user.email,
+
                           'createdAt': Timestamp.now(),
                         });
 

--- a/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
+++ b/campus_lost_found_app/lib/features/lost_items/screens/report_lost_item_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:campus_lost_found_app/features/ai_features/screens/lost_image_picker.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_image_labeling/google_mlkit_image_labeling.dart';
 import '../../../routes/app_routes.dart';
@@ -472,6 +473,8 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
                     );
                     String base64Image = base64Encode(compressedBytes);
 
+                    final user = FirebaseAuth.instance.currentUser;
+
                     await FirebaseFirestore.instance
                         .collection('lost_items')
                         .add({
@@ -482,6 +485,9 @@ class ReportLostItemScreenState extends State<ReportLostItemScreen> {
                           'description': descriptionController.text,
                           'imageBase64': base64Image,
                           'category': manualCategory ?? detectedCategory,
+                          'userId': user!.uid,
+                          'userEmail': user.email,
+
                           'createdAt': Timestamp.now(),
                         });
 

--- a/campus_lost_found_app/lib/features/reports/screens/my_reports_found_item_screen.dart
+++ b/campus_lost_found_app/lib/features/reports/screens/my_reports_found_item_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../routes/app_routes.dart';
+import 'dart:convert';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class MyFoundItemsScreen extends StatelessWidget {
   const MyFoundItemsScreen({super.key});
@@ -103,22 +106,43 @@ class _FoundTab extends StatelessWidget {
                                 color: const Color(0xFFEC7A3C),
                                 borderRadius: BorderRadius.circular(12),
                               ),
-                              child: const Column(
+                              child: Column(
                                 children: [
-                                  Text(
+                                  const Text(
                                     "Found Items",
                                     style: TextStyle(
                                       color: Colors.white,
                                       fontWeight: FontWeight.bold,
                                     ),
                                   ),
-                                  SizedBox(height: 4),
-                                  Text(
-                                    "Total: 2",
-                                    style: TextStyle(
-                                      color: Colors.white70,
-                                      fontSize: 12,
-                                    ),
+                                  const SizedBox(height: 4),
+
+                                  StreamBuilder<
+                                    QuerySnapshot<Map<String, dynamic>>
+                                  >(
+                                    stream: FirebaseFirestore.instance
+                                        .collection('found_items')
+                                        .where(
+                                          'userId',
+                                          isEqualTo: FirebaseAuth
+                                              .instance
+                                              .currentUser!
+                                              .uid,
+                                        )
+                                        .snapshots(),
+                                    builder: (context, snapshot) {
+                                      int count = snapshot.hasData
+                                          ? snapshot.data!.docs.length
+                                          : 0;
+
+                                      return Text(
+                                        "Total: $count",
+                                        style: const TextStyle(
+                                          color: Colors.white70,
+                                          fontSize: 12,
+                                        ),
+                                      );
+                                    },
                                   ),
                                 ],
                               ),
@@ -127,8 +151,32 @@ class _FoundTab extends StatelessWidget {
                         ],
                       ),
                       const SizedBox(height: 20),
-                      const _FoundItemCard(),
-                      const _FoundItemCard(),
+
+                      StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                        stream: FirebaseFirestore.instance
+                            .collection('found_items')
+                            .snapshots(),
+                        builder: (context, snapshot) {
+                          if (!snapshot.hasData) {
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
+                          }
+
+                          final uid = FirebaseAuth.instance.currentUser!.uid;
+
+                          final docs = snapshot.data!.docs.where((doc) {
+                            final data = doc.data();
+                            return data['userId'] == uid;
+                          }).toList();
+
+                          return Column(
+                            children: docs.map((doc) {
+                              return _FoundItemCard(data: doc);
+                            }).toList(),
+                          );
+                        },
+                      ),
                     ],
                   ),
                 ),
@@ -173,7 +221,9 @@ class _FoundTab extends StatelessWidget {
 }
 
 class _FoundItemCard extends StatelessWidget {
-  const _FoundItemCard();
+  final QueryDocumentSnapshot<Map<String, dynamic>> data;
+
+  const _FoundItemCard({required this.data});
 
   @override
   Widget build(BuildContext context) {
@@ -206,10 +256,12 @@ class _FoundItemCard extends StatelessWidget {
                   ),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(10),
-                    child: Image.asset(
-                      'assets/images/usb.jpg',
-                      fit: BoxFit.cover,
-                    ),
+                    child: data['imageBase64'] != null
+                        ? Image.memory(
+                            base64Decode(data['imageBase64']),
+                            fit: BoxFit.cover,
+                          )
+                        : const Icon(Icons.image),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -217,8 +269,8 @@ class _FoundItemCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Text(
-                        "USB Flash Drive",
+                      Text(
+                        data['itemName'] ?? '',
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
@@ -235,7 +287,7 @@ class _FoundItemCard extends StatelessWidget {
                           const SizedBox(width: 4),
                           Expanded(
                             child: Text(
-                              "Found at: Lab L104",
+                              "Found at: ${data['location'] ?? ''}",
                               style: TextStyle(
                                 fontSize: 12,
                                 color: Colors.grey[700],
@@ -254,7 +306,7 @@ class _FoundItemCard extends StatelessWidget {
                           ),
                           const SizedBox(width: 4),
                           Text(
-                            "Found on: 28 Jan 2026, 3:30 PM",
+                            "Found on: ${data['date'] ?? ''}, ${data['time'] ?? ''}",
                             style: TextStyle(
                               fontSize: 12,
                               color: Colors.grey[700],
@@ -293,11 +345,11 @@ class _FoundItemCard extends StatelessWidget {
             right: 6,
             child: IconButton(
               icon: const Icon(Icons.delete, color: Colors.red),
-              onPressed: () {
-                Navigator.pushNamed(
-                  context,
-                  AppRoutes.foundItemDeliveryConfirmation,
-                );
+              onPressed: () async {
+                await FirebaseFirestore.instance
+                    .collection('found_items')
+                    .doc(data.id)
+                    .delete();
               },
             ),
           ),

--- a/campus_lost_found_app/lib/features/reports/screens/my_reports_lost_item_screen.dart
+++ b/campus_lost_found_app/lib/features/reports/screens/my_reports_lost_item_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../routes/app_routes.dart';
+import 'dart:convert';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 class MyLostItemsScreen extends StatelessWidget {
   const MyLostItemsScreen({super.key});
@@ -65,22 +68,43 @@ class _LostTab extends StatelessWidget {
                                 color: const Color(0xFF254EBA),
                                 borderRadius: BorderRadius.circular(12),
                               ),
-                              child: const Column(
+                              child: Column(
                                 children: [
-                                  Text(
+                                  const Text(
                                     "Lost Items",
                                     style: TextStyle(
                                       color: Colors.white,
                                       fontWeight: FontWeight.bold,
                                     ),
                                   ),
-                                  SizedBox(height: 4),
-                                  Text(
-                                    "Total: 2",
-                                    style: TextStyle(
-                                      color: Colors.white70,
-                                      fontSize: 12,
-                                    ),
+                                  const SizedBox(height: 4),
+
+                                  StreamBuilder<
+                                    QuerySnapshot<Map<String, dynamic>>
+                                  >(
+                                    stream: FirebaseFirestore.instance
+                                        .collection('lost_items')
+                                        .where(
+                                          'userId',
+                                          isEqualTo: FirebaseAuth
+                                              .instance
+                                              .currentUser!
+                                              .uid,
+                                        )
+                                        .snapshots(),
+                                    builder: (context, snapshot) {
+                                      int count = snapshot.hasData
+                                          ? snapshot.data!.docs.length
+                                          : 0;
+
+                                      return Text(
+                                        "Total: $count",
+                                        style: const TextStyle(
+                                          color: Colors.white70,
+                                          fontSize: 12,
+                                        ),
+                                      );
+                                    },
                                   ),
                                 ],
                               ),
@@ -102,22 +126,43 @@ class _LostTab extends StatelessWidget {
                                   borderRadius: BorderRadius.circular(12),
                                   border: Border.all(color: Colors.grey),
                                 ),
-                                child: const Column(
+                                child: Column(
                                   children: [
-                                    Text(
+                                    const Text(
                                       "Found Items",
                                       style: TextStyle(
                                         color: Colors.black87,
                                         fontWeight: FontWeight.w600,
                                       ),
                                     ),
-                                    SizedBox(height: 4),
-                                    Text(
-                                      "Total: 2",
-                                      style: TextStyle(
-                                        color: Colors.black54,
-                                        fontSize: 12,
-                                      ),
+                                    const SizedBox(height: 4),
+
+                                    StreamBuilder<
+                                      QuerySnapshot<Map<String, dynamic>>
+                                    >(
+                                      stream: FirebaseFirestore.instance
+                                          .collection('found_items')
+                                          .where(
+                                            'userId',
+                                            isEqualTo: FirebaseAuth
+                                                .instance
+                                                .currentUser!
+                                                .uid,
+                                          )
+                                          .snapshots(),
+                                      builder: (context, snapshot) {
+                                        int count = snapshot.hasData
+                                            ? snapshot.data!.docs.length
+                                            : 0;
+
+                                        return Text(
+                                          "Total: $count",
+                                          style: const TextStyle(
+                                            color: Colors.black54,
+                                            fontSize: 12,
+                                          ),
+                                        );
+                                      },
                                     ),
                                   ],
                                 ),
@@ -127,8 +172,31 @@ class _LostTab extends StatelessWidget {
                         ],
                       ),
                       const SizedBox(height: 20),
-                      const _LostItemCard(),
-                      const _LostItemCard(),
+                      StreamBuilder(
+                        stream: FirebaseFirestore.instance
+                            .collection('lost_items')
+                            .where(
+                              'userId',
+                              isEqualTo: FirebaseAuth.instance.currentUser!.uid,
+                            )
+                            .snapshots(),
+
+                        builder: (context, snapshot) {
+                          if (!snapshot.hasData) {
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
+                          }
+
+                          final docs = snapshot.data!.docs;
+
+                          return Column(
+                            children: docs.map((doc) {
+                              return _LostItemCard(data: doc);
+                            }).toList(),
+                          );
+                        },
+                      ),
                     ],
                   ),
                 ),
@@ -173,7 +241,9 @@ class _LostTab extends StatelessWidget {
 }
 
 class _LostItemCard extends StatelessWidget {
-  const _LostItemCard();
+  final QueryDocumentSnapshot<Map<String, dynamic>> data;
+
+  const _LostItemCard({required this.data});
 
   @override
   Widget build(BuildContext context) {
@@ -206,10 +276,12 @@ class _LostItemCard extends StatelessWidget {
                   ),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(10),
-                    child: Image.asset(
-                      'assets/images/black_wallet.png',
-                      fit: BoxFit.cover,
-                    ),
+                    child: data['imageBase64'] != null
+                        ? Image.memory(
+                            base64Decode(data['imageBase64']),
+                            fit: BoxFit.cover,
+                          )
+                        : const Icon(Icons.image),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -217,8 +289,8 @@ class _LostItemCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Text(
-                        "Black Wallet",
+                      Text(
+                        data['itemName'] ?? '',
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,
@@ -235,7 +307,7 @@ class _LostItemCard extends StatelessWidget {
                           const SizedBox(width: 4),
                           Expanded(
                             child: Text(
-                              "Lost at: University Library - 2nd Floor",
+                              "Lost at: ${data['location'] ?? ''}",
                               style: TextStyle(
                                 fontSize: 12,
                                 color: Colors.grey[700],
@@ -254,7 +326,7 @@ class _LostItemCard extends StatelessWidget {
                           ),
                           const SizedBox(width: 4),
                           Text(
-                            "Lost on: 28 Jan 2026, 3:30 PM",
+                            "Lost on: ${data['date'] ?? ''}, ${data['time'] ?? ''}",
                             style: TextStyle(
                               fontSize: 12,
                               color: Colors.grey[700],
@@ -292,11 +364,11 @@ class _LostItemCard extends StatelessWidget {
             right: 6,
             child: IconButton(
               icon: const Icon(Icons.delete, color: Colors.red),
-              onPressed: () {
-                Navigator.pushNamed(
-                  context,
-                  AppRoutes.lostItemDeliveryConfirmation,
-                );
+              onPressed: () async {
+                await FirebaseFirestore.instance
+                    .collection('lost_items')
+                    .doc(data.id)
+                    .delete();
               },
             ),
           ),


### PR DESCRIPTION
- Connected My Lost Reports page to Firestore
- Connected My Found Reports page to Firestore
- Show only reports created by currently logged-in user
- Added userId filtering using Firebase Auth UID
- Added live total count for Lost and Found reports
- Replaced static dummy cards with dynamic Firebase data
- Display real item name, date, time, location, and image
- Added delete functionality for own reports
- Fixed missing userId field crash with safe null handling
- Preserved existing UI design without layout changes